### PR TITLE
Bump ethereum-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dnsdisc = { git = "https://github.com/rust-ethereum/dnsdisc", optional = true }
 educe = { version = "0.4", default-features = false, features = ["Clone", "Debug", "Default"] }
 enr = { git = "https://github.com/rust-ethereum/enr", default-features = false, features = ["rust-secp256k1"] }
 enum-primitive-derive = "0.2"
-ethereum-types = { version = "0.10", default-features = false, features = ["std", "rlp"] }
+ethereum-types = { version = "0.11", default-features = false, features = ["std", "rlp"] }
 futures = "0.3"
 futures-intrusive = "0.4"
 generic-array = "0.14"


### PR DESCRIPTION
But examples `local_connect` and `sentry` still can't work.
```
thread 'main' panicked at 'must be called from the context of Tokio runtime configured with either `basic_scheduler` or `threaded_scheduler`'
```